### PR TITLE
#17_added & configured Dotenv dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@babel/preset-react": "^7.18.6",
     "babel-loader": "^8.2.5",
     "css-loader": "^6.7.1",
+    "dotenv": "^16.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "webpack": "^5.74.0",

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -2,6 +2,7 @@ const App = () => {
   return(
     <>
       <h1>Speed Reader</h1>
+      
     </>
   );
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,7 @@
 const path = require('path');
 const webpack = require('webpack');
+const {DefinePlugin}=require('webpack')
+const dotenv=require('dotenv')
 const htmlWebpackPlugin = require('html-webpack-plugin');
 
 const isProd = process.env.NODE_ENV === 'production';
@@ -47,6 +49,13 @@ const config = {
     new webpack.ProvidePlugin({
       React: 'react',
     }),
+
+    //allow .env configuration
+   
+      new DefinePlugin({
+        'process.env': JSON.stringify(dotenv.config().parsed)
+      })
+
   ],
 
   // Allows us to import modules without needing to add their extensions

--- a/yarn.lock
+++ b/yarn.lock
@@ -1878,6 +1878,11 @@ dot-case@^3.0.4:
     no-case "^3.0.4"
     tslib "^2.0.3"
 
+dotenv@^16.0.3:
+  version "16.0.3"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.3.tgz#115aec42bac5053db3c456db30cc243a5a836a07"
+  integrity sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"


### PR DESCRIPTION
This PR tries to resolve #17.

## Adding and Configuring Dotenv Dependency

1. added " dotenv " package in package.json 
2. Configured webpack , using DefinePlugin module .
 

## Outcome
now user can use ".env" file  to secure their "Api keys " and confidencial stuffs .

## Screenshots (for testing added in ui but didn't included that in code)

![Screenshot (47)](https://user-images.githubusercontent.com/83210491/194369269-2c561715-6087-4a8b-9653-86bb05bc72cf.png)
