### PR TITLE
Bug/Correct What Section Markdown in PR Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 If the PR tries to resolve any Open Issue, make sure to include the text.
 **The PR tries to resolve #<ISSUE-NUMBER>.**
 
-# What
+## What
 Add a description about proposed changes addressed into the PR.
 
 ## Why


### PR DESCRIPTION
## What
Converted `what` section in PR template to **h2** tag from **h1** tag.

## Why
PR template needs to be uniform with other sections.

- [x] I will abide by the [code of conduct](https://github.com/bhavik2936/speed-reader/blob/main/.github/CODE_OF_CONDUCT.md).
