### PR TITLE
Chore/Add Prop Types to Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "babel-loader": "^9.1.2",
     "css-loader": "^6.8.1",
     "dotenv": "^16.3.1",
+    "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "webpack": "^5.88.2",


### PR DESCRIPTION
## What
Added `prop-types` to `package.json` as dependency.
As it is dependency of `eslint-plugin-react` library, no differences are seen in `yarn.lock`.

## Why
It is recommended to perform type-checking.

- [x] I will abide by the [code of conduct](https://github.com/bhavik2936/speed-reader/blob/main/.github/CODE_OF_CONDUCT.md).
